### PR TITLE
fix(server): remove passport JWT authentication from /movies endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ app.get('/', (req, res) => {
 
 
 // Return a list of ALL movies to the user (requires authentication)
-app.get('/movies', passport.authenticate('jwt', { session: false }), async (req, res) => {
+app.get('/movies', async (req, res) => {
     await Movies.find()
         .then((movies) => {
             res.status(201).json(movies);


### PR DESCRIPTION
Removed passport.authenticate('jwt', { session: false }), from the /movies endpoint in index.js